### PR TITLE
Just add the "()" to the startup call

### DIFF
--- a/examples/1-full-electronsample/1-full-electronsample.cpp
+++ b/examples/1-full-electronsample/1-full-electronsample.cpp
@@ -25,7 +25,7 @@ void startup() {
 	System.enableFeature(FEATURE_RETAINED_MEMORY);
 	System.enableFeature(FEATURE_RESET_INFO);
 }
-STARTUP(startup);
+STARTUP(startup());
 
 // System threaded mode is not required here, but it's a good idea with 0.6.0 and later.
 // https://docs.particle.io/reference/firmware/electron/#system-thread


### PR DESCRIPTION
The example wasn't working and I think it's because the startup function wasn't called